### PR TITLE
docs(acpx): clarify exec vs prompt --session, add --cwd workflows

### DIFF
--- a/acpx/skills/use-acpx/SKILL.md
+++ b/acpx/skills/use-acpx/SKILL.md
@@ -31,7 +31,7 @@ Core capabilities:
 
 - Persistent multi-turn sessions per repo/cwd
 - One-shot execution mode (`exec`)
-- Named parallel sessions (`-s/--session`)
+- Named parallel sessions (`-s/--session`, `prompt` verb only)
 - Queue-aware prompt submission with optional fire-and-forget (`--no-wait`)
 - Cooperative cancel command (`cancel`) for in-flight turns
 - Graceful cancellation via ACP `session/cancel` on interrupt
@@ -112,14 +112,7 @@ acpx codex exec 'summarize this repo'
 
 Runs a single prompt in a temporary session; does not reuse or persist session state.
 
-**Note**: `-s/--session` is a `prompt`-verb option only — it does not apply to `exec`. For parallel one-shot tasks, run multiple `acpx ... exec` processes with different `--cwd` values; each process is independently isolated by its working directory.
-
-```bash
-# Parallel one-shot tasks across separate working dirs (no --session needed)
-acpx --cwd /tmp/wt-A codex exec 'task A' &
-acpx --cwd /tmp/wt-B codex exec 'task B' &
-wait
-```
+**Note**: `-s/--session` is a `prompt`-verb option only — it does not apply to `exec`. For parallel one-shot patterns across separate working dirs, see the Cross-repo / worktree section below.
 
 ### Cancel / Mode / Set
 
@@ -212,11 +205,13 @@ acpx --cwd /home/dev/code/projectB codex exec 'audit failing CI in projectB'
 acpx --cwd /tmp/codex-worktrees/feat-A codex exec 'task A' &
 acpx --cwd /tmp/codex-worktrees/feat-B codex exec 'task B' &
 wait
+# Note: when calling from Claude Code Bash tool, use run_in_background: true
+# per-call instead — the &+wait pattern blocks the tool until both complete.
 ```
 
 The `--cwd` overrides the working directory the agent sees, but skills, MCP
 servers, and config are still loaded from the user's home (`~/.codex/` for
-codex). Add the target paths to `[projects."<path>"]` in the agent config to
-avoid trust prompts on first use.
+codex). Add the target paths to `[projects."<path>"]` in `~/.codex/config.toml`
+(Codex-side TOML config) to avoid trust prompts on first use.
 
 For more examples including stdin/file prompts, session management, and JSON automation pipelines, see `./references/cli.md`.

--- a/acpx/skills/use-acpx/SKILL.md
+++ b/acpx/skills/use-acpx/SKILL.md
@@ -112,6 +112,15 @@ acpx codex exec 'summarize this repo'
 
 Runs a single prompt in a temporary session; does not reuse or persist session state.
 
+**Note**: `-s/--session` is a `prompt`-verb option only — it does not apply to `exec`. For parallel one-shot tasks, run multiple `acpx ... exec` processes with different `--cwd` values; each process is independently isolated by its working directory.
+
+```bash
+# Parallel one-shot tasks across separate working dirs (no --session needed)
+acpx --cwd /tmp/wt-A codex exec 'task A' &
+acpx --cwd /tmp/wt-B codex exec 'task B' &
+wait
+```
+
 ### Cancel / Mode / Set
 
 ```bash
@@ -191,5 +200,23 @@ acpx --format json codex 'review current branch changes' > events.ndjson
 acpx --cwd ~/repos/shop --approve-all codex -s pr-842 \
   'review PR #842 for regressions and propose minimal patch'
 ```
+
+Cross-repo / worktree delegation (current repo stays untouched):
+
+```bash
+# Same shell stays on the orchestration repo; the agent works elsewhere
+acpx --cwd /home/dev/code/projectB codex exec 'audit failing CI in projectB'
+
+# Parallel one-shots on isolated worktrees — no --session needed,
+# each acpx process is naturally isolated by its --cwd
+acpx --cwd /tmp/codex-worktrees/feat-A codex exec 'task A' &
+acpx --cwd /tmp/codex-worktrees/feat-B codex exec 'task B' &
+wait
+```
+
+The `--cwd` overrides the working directory the agent sees, but skills, MCP
+servers, and config are still loaded from the user's home (`~/.codex/` for
+codex). Add the target paths to `[projects."<path>"]` in the agent config to
+avoid trust prompts on first use.
 
 For more examples including stdin/file prompts, session management, and JSON automation pipelines, see `./references/cli.md`.


### PR DESCRIPTION
## Summary

Two precision additions to `acpx/skills/use-acpx/SKILL.md`, both stemming from real-world ambiguities encountered when delegating Codex tasks from an orchestrating Claude Code session.

### 1. `-s/--session` applies to `prompt` only, not `exec`

The current skill lists `Named parallel sessions (-s/--session)` as a core capability without specifying which verb it applies to. In practice it's a `prompt`-verb option (persistent sessions), and combining it with `exec` either errors out or silently ignores the flag depending on the version.

For parallel one-shot tasks via `exec`, the natural pattern is multiple processes with distinct `--cwd` values — each `acpx` process is isolated by its working directory, no session bookkeeping needed. Added a small example.

### 2. Cross-repo / worktree delegation pattern

Added explicit examples of `acpx --cwd <path> codex exec` from an orchestrator that stays on its own repo. Includes a note about `[projects."<path>"]` trust entries (Codex side) to avoid first-use prompts.

## Why

When using `acpx` as part of a larger orchestration (Claude Code delegating to Codex), these two patterns come up often. Currently a reader has to discover them by trial and error — the second pattern doesn't appear anywhere in the existing examples.

## Changes

- `acpx/skills/use-acpx/SKILL.md` only.
- Documentation; no behavior changes.

## Test plan

- [x] Verified locally that the patterns described work as documented (Linux x86_64, acpx 0.6.1, codex 0.125.0).
- [x] Read the skill end-to-end to ensure the new sections fit the existing tone and structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)